### PR TITLE
update easy pjax to work with django 1.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ python:
   - "2.7"
   - "3.2"
   - "3.3"
+  - "3.4"
 
 env:
   - DJANGO_VERSION=1.4
@@ -19,6 +20,9 @@ matrix:
       env: DJANGO_VERSION=1.4
     - python: "3.3"
       env: DJANGO_VERSION=1.4
+    - python: "3.4"
+      env: DJANGO_VERSION=1.4
+
 
 install:
   - pip install Django==$DJANGO_VERSION

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,8 @@ env:
   - DJANGO_VERSION=1.4
   - DJANGO_VERSION=1.5
   - DJANGO_VERSION=1.6
+  - DJANGO_VERSION=1.7
+  - DJANGO_VERSION=1.8
 
 matrix:
   exclude:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,10 @@ env:
 
 matrix:
   exclude:
+    - python: "2.6"
+      env: DJANGO_VERSION=1.7
+    - python: "2.6"
+      env: DJANGO_VERSION=1.8
     - python: "3.2"
       env: DJANGO_VERSION=1.4
     - python: "3.3"

--- a/easy_pjax/__init__.py
+++ b/easy_pjax/__init__.py
@@ -11,5 +11,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 __version__ = "1.1.0"
 
 
-from django.template import add_to_builtins
+try:
+    from django.template import add_to_builtins
+except ImportError:
+    # import path changed in 1.8
+    from django.template.base import add_to_builtins
+
 add_to_builtins("easy_pjax.templatetags.pjax_tags")

--- a/run_tests.py
+++ b/run_tests.py
@@ -37,7 +37,7 @@ from django.test.utils import get_runner
 
 
 def run_tests(verbosity, interactive, failfast, test_labels):
-    if django.get_version() >= '1.7.0':
+    if django.get_version() >= '1.7':
         # Django 1.7 changed how apps are loaded so this call is necessary to
         # configure some settings
         django.setup()

--- a/run_tests.py
+++ b/run_tests.py
@@ -4,6 +4,7 @@ import os
 import sys
 from optparse import OptionParser
 
+import django
 from django.conf import settings, global_settings
 
 
@@ -36,6 +37,11 @@ from django.test.utils import get_runner
 
 
 def run_tests(verbosity, interactive, failfast, test_labels):
+    if django.get_version() >= '1.7.0':
+        # Django 1.7 changed how apps are loaded so this call is necessary to
+        # configure some settings
+        django.setup()
+
     if not test_labels:
         test_labels = ["tests"]
 

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -10,11 +10,16 @@ from django.test.client import RequestFactory, Client
 class UnpjaxMiddlewareTestCase(TestCase):
     def test_without_middleware(self):
         response = self.client.get("/unpjax/?param=1")
-        content = response.content.decode(response._charset)
+        charset = response._charset
+
+        if charset is None:
+            charset = 'UTF-8'
+
+        content = response.content.decode(charset)
         self.assertHTMLEqual('<a href="/unpjax/?param=1"></a>', content)
 
         response = self.client.get("/unpjax/?param=1&_pjax=true", HTTP_X_PJAX=True)
-        content = response.content.decode(response._charset)
+        content = response.content.decode(charset)
         self.assertHTMLEqual('<a href="/unpjax/?param=1&_pjax=true"></a>',
                              content)
 
@@ -26,25 +31,40 @@ class UnpjaxMiddlewareTestCase(TestCase):
             client = Client()
 
             response = client.get("/unpjax/?param=1")
-            content = response.content.decode(response._charset)
+            charset = response._charset
+
+            if charset is None:
+                charset = 'UTF-8'
+
+            content = response.content.decode(charset)
             self.assertHTMLEqual('<a href="/unpjax/?param=1"></a>', content)
 
             response = client.get("/unpjax/?param=1&_pjax=true", HTTP_X_PJAX=True)
-            content = response.content.decode(response._charset)
+            content = response.content.decode(charset)
             self.assertHTMLEqual('<a href="/unpjax/?param=1"></a>', content)
 
 
 class UnpjaxFilterTestCase(TestCase):
     def test_regular_request(self):
         response = self.client.get("/unpjax-filter/?param=1")
-        content = response.content.decode(response._charset)
+        charset = response._charset
+
+        if charset is None:
+            charset = 'UTF-8'
+
+        content = response.content.decode(charset)
         self.assertHTMLEqual('<a href="/unpjax-filter/?param=1"></a>',
                              content)
 
     def test_pjax_request(self):
         response = self.client.get("/unpjax-filter/?param=1&_pjax=true",
             HTTP_X_PJAX=True)
-        content = response.content.decode(response._charset)
+        charset = response._charset
+
+        if charset is None:
+            charset = 'UTF-8'
+
+        content = response.content.decode(charset)
         self.assertHTMLEqual('<a href="/unpjax-filter/?param=1"></a>',
                              content)
 


### PR DESCRIPTION
In Django 1.8 the import path for `add_to_builtins` changed. Getting this to work led to a few other issues that I also tried to address.

I'm not sure why the Django 1.4 / Python 2.7 combination are failing in Travis.