### PR TITLE
Fix non-ascii character handling in query strings on Python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 language: python
 
+cache: pip
+
 python:
   - "2.6"
   - "2.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ python:
   - "3.5"
 
 env:
-  - DJANGO_VERSION=">=1.4,<1.5"
   - DJANGO_VERSION="==1.5"
   - DJANGO_VERSION=">=1.5,<1.6"
   - DJANGO_VERSION="==1.6"

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -3,10 +3,12 @@
 History
 -------
 
-1.3.0 (2016-02-20)
+1.3.0 (2016-02-21)
 ++++++++++++++++++
 
-* Django 1.9 support (the plugin should be added to ``TEMPLATES["OPTIONS"]["builtins"]`` settings)
+* Django 1.9 support (the plugin should be added to ``TEMPLATES["OPTIONS"]["builtins"]``
+  settings) - `#13 <https://github.com/nigma/django-easy-pjax/pull/13>`_
+* Fix handling of non-ascii query strings on Python 2.7 - `#14 <https://github.com/nigma/django-easy-pjax/pull/13>`_
 
 1.2.0 (2015-04-23)
 ++++++++++++++++++

--- a/easy_pjax/middleware.py
+++ b/easy_pjax/middleware.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from django.http import QueryDict
+from django.utils.encoding import smart_str
 
 
 class UnpjaxMiddleware(object):
@@ -15,4 +16,4 @@ class UnpjaxMiddleware(object):
             qs = QueryDict(request.META.get("QUERY_STRING", ""),
                            encoding=request.encoding, mutable=True)
             qs.pop("_pjax", None)
-            request.META["QUERY_STRING"] = qs.urlencode()
+            request.META["QUERY_STRING"] = smart_str(qs.urlencode())

--- a/easy_pjax/templatetags/pjax_tags.py
+++ b/easy_pjax/templatetags/pjax_tags.py
@@ -4,9 +4,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from django import template
 from django.http import QueryDict
-
-# Note: this file is automatically added to Django template builtins
-# by the easy_pjax.__init__ module.
+from django.utils.encoding import smart_str
 
 register = template.Library()
 
@@ -53,7 +51,7 @@ def unpjax(url):
     if "?" in url:
         base, qs = url.split("?", 1)
         if "_pjax" in qs:
-            qs = QueryDict(qs, mutable=True)
+            qs = QueryDict(smart_str(qs), mutable=True)
             qs.pop("_pjax", None)
             qs = qs.urlencode()
             if qs:

--- a/tests/templates/unpjax_filter.html
+++ b/tests/templates/unpjax_filter.html
@@ -1,1 +1,1 @@
-<a href="{{ request.get_full_path|unpjax }}"></a>
+<a href="{{ request.get_full_path|unpjax }}">{{ request.GET.param }}</a>

--- a/tests/templates/unpjax_middleware.html
+++ b/tests/templates/unpjax_middleware.html
@@ -1,1 +1,1 @@
-<a href="{{ request.get_full_path }}"></a>
+<a href="{{ request.get_full_path }}">{{ request.GET.param }}</a>

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -15,17 +15,17 @@ class UnpjaxMiddlewareTestCase(TestCase):
         self.param_encoded = urlencode({"param": self.param})
 
     def test_without_middleware(self):
-        response = self.client.get("/unpjax/?{}".format(self.param_encoded))
+        response = self.client.get("/unpjax/?{0}".format(self.param_encoded))
         charset = response._charset
 
         if charset is None:
             charset = 'UTF-8'
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax/?{}">{}</a>'.format(self.param_encoded, self.param), content)
+        self.assertHTMLEqual('<a href="/unpjax/?{0}">{1}</a>'.format(self.param_encoded, self.param), content)
 
-        response = self.client.get("/unpjax/?{}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
+        response = self.client.get("/unpjax/?{0}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax/?{}&_pjax=true">{}</a>'.format(self.param_encoded, self.param), content)
+        self.assertHTMLEqual('<a href="/unpjax/?{0}&_pjax=true">{1}</a>'.format(self.param_encoded, self.param), content)
 
     def test_with_middleware(self):
         MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + ["easy_pjax.middleware.UnpjaxMiddleware"]
@@ -33,18 +33,18 @@ class UnpjaxMiddlewareTestCase(TestCase):
         with self.settings(MIDDLEWARE_CLASSES=MIDDLEWARE_CLASSES):
             client = Client()
 
-            response = client.get("/unpjax/?{}".format(self.param_encoded))
+            response = client.get("/unpjax/?{0}".format(self.param_encoded))
             charset = response._charset
 
             if charset is None:
                 charset = 'UTF-8'
 
             content = response.content.decode(charset)
-            self.assertHTMLEqual('<a href="/unpjax/?{}">{}</a>'.format(self.param_encoded, self.param), content)
+            self.assertHTMLEqual('<a href="/unpjax/?{0}">{1}</a>'.format(self.param_encoded, self.param), content)
 
-            response = client.get("/unpjax/?{}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
+            response = client.get("/unpjax/?{0}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
             content = response.content.decode(charset)
-            self.assertHTMLEqual('<a href="/unpjax/?{}">{}</a>'.format(self.param_encoded, self.param), content)
+            self.assertHTMLEqual('<a href="/unpjax/?{0}">{1}</a>'.format(self.param_encoded, self.param), content)
 
 
 class UnpjaxMiddlewareNonAsciiTestCase(UnpjaxMiddlewareTestCase):
@@ -61,24 +61,24 @@ class UnpjaxFilterTestCase(TestCase):
         self.param_encoded = urlencode({"param": self.param})
 
     def test_regular_request(self):
-        response = self.client.get("/unpjax-filter/?{}".format(self.param_encoded))
+        response = self.client.get("/unpjax-filter/?{0}".format(self.param_encoded))
         charset = response._charset
 
         if charset is None:
             charset = 'UTF-8'
 
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax-filter/?{}">{}</a>'.format(self.param_encoded, self.param), content)
+        self.assertHTMLEqual('<a href="/unpjax-filter/?{0}">{1}</a>'.format(self.param_encoded, self.param), content)
 
     def test_pjax_request(self):
-        response = self.client.get("/unpjax-filter/?{}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
+        response = self.client.get("/unpjax-filter/?{0}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
         charset = response._charset
 
         if charset is None:
             charset = 'UTF-8'
 
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax-filter/?{}">{}</a>'.format(self.param_encoded, self.param), content)
+        self.assertHTMLEqual('<a href="/unpjax-filter/?{0}">{1}</a>'.format(self.param_encoded, self.param), content)
 
 
 class UnpjaxFilterNonAsciiTestCase(UnpjaxFilterTestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -5,64 +5,86 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from django.conf import settings
 from django.test.testcases import TestCase
 from django.test.client import RequestFactory, Client
+from django.utils.http import urlencode
 
 
 class UnpjaxMiddlewareTestCase(TestCase):
+
+    def setUp(self):
+        self.param = "1"
+        self.param_encoded = urlencode({"param": self.param})
+
     def test_without_middleware(self):
-        response = self.client.get("/unpjax/?param=1")
+        response = self.client.get("/unpjax/?{}".format(self.param_encoded))
         charset = response._charset
 
         if charset is None:
             charset = 'UTF-8'
-
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax/?param=1"></a>', content)
+        self.assertHTMLEqual('<a href="/unpjax/?{}">{}</a>'.format(self.param_encoded, self.param), content)
 
-        response = self.client.get("/unpjax/?param=1&_pjax=true", HTTP_X_PJAX=True)
+        response = self.client.get("/unpjax/?{}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax/?param=1&_pjax=true"></a>', content)
+        self.assertHTMLEqual('<a href="/unpjax/?{}&_pjax=true">{}</a>'.format(self.param_encoded, self.param), content)
 
     def test_with_middleware(self):
-        MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) +\
-            ["easy_pjax.middleware.UnpjaxMiddleware"]
+        MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + ["easy_pjax.middleware.UnpjaxMiddleware"]
 
         with self.settings(MIDDLEWARE_CLASSES=MIDDLEWARE_CLASSES):
             client = Client()
 
-            response = client.get("/unpjax/?param=1")
+            response = client.get("/unpjax/?{}".format(self.param_encoded))
             charset = response._charset
 
             if charset is None:
                 charset = 'UTF-8'
 
             content = response.content.decode(charset)
-            self.assertHTMLEqual('<a href="/unpjax/?param=1"></a>', content)
+            self.assertHTMLEqual('<a href="/unpjax/?{}">{}</a>'.format(self.param_encoded, self.param), content)
 
-            response = client.get("/unpjax/?param=1&_pjax=true", HTTP_X_PJAX=True)
+            response = client.get("/unpjax/?{}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
             content = response.content.decode(charset)
-            self.assertHTMLEqual('<a href="/unpjax/?param=1"></a>', content)
+            self.assertHTMLEqual('<a href="/unpjax/?{}">{}</a>'.format(self.param_encoded, self.param), content)
+
+
+class UnpjaxMiddlewareNonAsciiTestCase(UnpjaxMiddlewareTestCase):
+
+    def setUp(self):
+        self.param = "xyząśżźćół"
+        self.param_encoded = urlencode({"param": self.param})
 
 
 class UnpjaxFilterTestCase(TestCase):
+
+    def setUp(self):
+        self.param = "1"
+        self.param_encoded = urlencode({"param": self.param})
+
     def test_regular_request(self):
-        response = self.client.get("/unpjax-filter/?param=1")
+        response = self.client.get("/unpjax-filter/?{}".format(self.param_encoded))
         charset = response._charset
 
         if charset is None:
             charset = 'UTF-8'
 
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax-filter/?param=1"></a>', content)
+        self.assertHTMLEqual('<a href="/unpjax-filter/?{}">{}</a>'.format(self.param_encoded, self.param), content)
 
     def test_pjax_request(self):
-        response = self.client.get("/unpjax-filter/?param=1&_pjax=true", HTTP_X_PJAX=True)
+        response = self.client.get("/unpjax-filter/?{}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
         charset = response._charset
 
         if charset is None:
             charset = 'UTF-8'
 
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax-filter/?param=1"></a>', content)
+        self.assertHTMLEqual('<a href="/unpjax-filter/?{}">{}</a>'.format(self.param_encoded, self.param), content)
+
+
+class UnpjaxFilterNonAsciiTestCase(UnpjaxFilterTestCase):
+    def setUp(self):
+        self.param = "xyząśżźćół"
+        self.param_encoded = urlencode({"param": self.param})
 
 
 class TemplateFilterChoiceTestCase(TestCase):

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -25,7 +25,8 @@ class UnpjaxMiddlewareTestCase(TestCase):
 
         response = self.client.get("/unpjax/?{0}&_pjax=true".format(self.param_encoded), HTTP_X_PJAX=True)
         content = response.content.decode(charset)
-        self.assertHTMLEqual('<a href="/unpjax/?{0}&_pjax=true">{1}</a>'.format(self.param_encoded, self.param), content)
+        self.assertHTMLEqual('<a href="/unpjax/?{0}&_pjax=true">{1}</a>'.format(
+            self.param_encoded, self.param), content)
 
     def test_with_middleware(self):
         MIDDLEWARE_CLASSES = list(settings.MIDDLEWARE_CLASSES) + ["easy_pjax.middleware.UnpjaxMiddleware"]


### PR DESCRIPTION
- Fixes #8 
- Removes Django 1.4 from travis.yml